### PR TITLE
Update taxon rank filtering

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -12,3 +12,4 @@ dependencies:
     - meerkat-ml
     - jupyterlab
     - pybioclip
+    - polars


### PR DESCRIPTION
Updates `load_taxon_keys` to use `polars` to filter and generate unique list of relevant taxa at the desired level.

Adds `hole` and `circle` to taxon list if filtering for images of holes too.