### PR TITLE
post-V51 reformatting and filter

### DIFF
--- a/BoB_filter.py
+++ b/BoB_filter.py
@@ -24,12 +24,17 @@ def get_json_tags(v51_json):
   for i in range(len(v51_json["samples"])):
     img_info = v51_json["samples"][i]
     taxa_by_image["filepath"] = img_info["filepath"]
+    included_tags = ["filepath"]
     for tag in img_info["tags"]:
       tag_parts = tag.split("_")
       if tag_parts[0] not in EXPECTED_COLS:
         print(f"The preface {tag_parts[0]} associated with image {taxa_by_image['filepath']} is not an column ({EXPECTED_COLS}), please note it will not be included")
         continue
       taxa_by_image[tag_parts[0]] = tag_parts[1]
+      included_tags.append(tag_parts[0])
+    null_tags = [col for col in EXPECTED_COLS if col not in included_tags]
+    for i in range(len(null_tags)):
+      taxa_by_image[null_tags[i]] = None
     df = pl.concat([df, pl.DataFrame(data = taxa_by_image)], how = "diagonal_relaxed")
 
   return df

--- a/BoB_filter.py
+++ b/BoB_filter.py
@@ -1,0 +1,54 @@
+'''
+Filter JSON following pybioclip and V51 pass.
+'''
+
+#from bioclip import CustomLabelsClassifier
+import polars as pl
+import json
+import argparse
+#import uuid
+
+EXPECTED_COLS = ["filepath", "kingdom", "phylum", "class", "order", "family", "genus", "species", "unknown", "abiotic"]
+TAXA_COLS = EXPECTED_COLS[:-2]
+
+
+def get_json_tags(v51_json):
+  '''
+  Creates a DataFrame with all images and the ranks that were classified for images in V51.
+  
+  Args:
+
+  '''
+  taxa_by_image = {}
+  df = pl.DataFrame(schema = EXPECTED_COLS)
+  for i in range(len(v51_json["samples"])):
+    img_info = v51_json["samples"][i]
+    taxa_by_image["filepath"] = img_info["filepath"]
+    for tag in img_info["tags"]:
+      tag_parts = tag.split("_")
+      if tag_parts[0] not in EXPECTED_COLS:
+        print(f"The preface {tag_parts[0]} associated with image {taxa_by_image['filepath']} is not an column ({EXPECTED_COLS}), please note it will not be included")
+        continue
+      taxa_by_image[tag_parts[0]] = tag_parts[1]
+    df = pl.concat([df, pl.DataFrame(data = taxa_by_image)], how = "diagonal_relaxed")
+
+  return df
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--json-path", required = True, help = "path to json output from V51")
+  parser.add_argument("--output-path", required = True, help = "where to save classification CSV (ex: V51_first_classification.csv)")
+  args = parser.parse_args()
+  with open(args.json_path) as file:
+    v51_json = json.load(file)
+  df = get_json_tags(v51_json)
+  print(f"Writing prediction table to {args.output_path}")
+  df.write_csv(args.output_path)
+
+'''
+classifier = CustomLabelsClassifier(["insect", "hole"])
+predictions = classifier.predict("example_moth.jpg")
+for prediction in predictions:
+   print(prediction["classification"], prediction["score"])
+'''

--- a/datasets/test_images/test.json
+++ b/datasets/test_images/test.json
@@ -1,0 +1,15 @@
+{"samples": 
+[{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c6"}, 
+"filepath": "data\\liquidSerau_2024_08_06__19_15_05_HDR0_crop_6.jpg", 
+"tags": ["order_Orthoptera", "family_gryllidae"], 
+"_media_type": "image", 
+"_rand": 0.9991719170376834, 
+"_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}},
+
+{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c7"}, 
+"filepath": "data\\liquidSerau_2024_08_06__19_17_05_HDR0_crop_5.jpg", 
+"tags": ["order_Orthoptera", "family_gryllidae"], 
+"_media_type": "image", "_rand": 0.9995640184600508, "_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}},
+{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c8"}, "filepath": "data\\liquidSerau_2024_08_06__19_19_05_HDR0_crop_3.jpg", "tags": ["order_Orthoptera", "family_gryllidae"], "_media_type": "image", "_rand": 0.9998202003574216, "_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}},
+{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c8"}, "filepath": "data\\liquidSerau_2024_08_06__19_19_05_HDR0_crop_4.jpg", "tags": ["abiotic_Orthoptera"], "_media_type": "image", "_rand": 0.9998202003574216, "_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}}
+]}

--- a/datasets/test_images/test.json
+++ b/datasets/test_images/test.json
@@ -1,15 +1,27 @@
 {"samples": 
 [{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c6"}, 
-"filepath": "data\\liquidSerau_2024_08_06__19_15_05_HDR0_crop_6.jpg", 
+"filepath": "data/crop_6.jpg", 
 "tags": ["order_Orthoptera", "family_gryllidae"], 
 "_media_type": "image", 
 "_rand": 0.9991719170376834, 
 "_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}},
 
 {"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c7"}, 
-"filepath": "data\\liquidSerau_2024_08_06__19_17_05_HDR0_crop_5.jpg", 
+"filepath": "data/crop_5.jpg", 
 "tags": ["order_Orthoptera", "family_gryllidae"], 
 "_media_type": "image", "_rand": 0.9995640184600508, "_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}},
-{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c8"}, "filepath": "data\\liquidSerau_2024_08_06__19_19_05_HDR0_crop_3.jpg", "tags": ["order_Orthoptera", "family_gryllidae"], "_media_type": "image", "_rand": 0.9998202003574216, "_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}},
-{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c8"}, "filepath": "data\\liquidSerau_2024_08_06__19_19_05_HDR0_crop_4.jpg", "tags": ["abiotic_Orthoptera"], "_media_type": "image", "_rand": 0.9998202003574216, "_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}}
+{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c6"}, 
+"filepath": "data/crop_2.jpg", 
+"tags": ["order_Lepidoptera", "family_saturniidae"], 
+"_media_type": "image", 
+"_rand": 0.9991719170376834, 
+"_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}},
+{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c8"}, "filepath": "data/crop_3.jpg", "tags": ["order_Orthoptera", "family_gryllidae"], "_media_type": "image", "_rand": 0.9998202003574216, "_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}},
+{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c8"}, "filepath": "data/crop_4.jpg", "tags": ["abiotic_hole"], "_media_type": "image", "_rand": 0.9998202003574216, "_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}},
+{"_id": {"$oid": "66bcfd3de94b8e7f77d8b1c6"}, 
+"filepath": "data/crop_1.jpg", 
+"tags": ["unknown_unidentifiable"], 
+"_media_type": "image", 
+"_rand": 0.9991719170376834, 
+"_dataset_id": {"$oid": "66bcfd1fe94b8e7f77d8b1bc"}}
 ]}


### PR DESCRIPTION
Adds the filtering function. Takes the V51 JSON output and reformats to output CSV with taxonomic and other labels. 

Next step will be to produce lists for second `pybioclip` run. Documentation of how these work is still required.